### PR TITLE
Modificação de lógica devido ao lançamento de exceção.

### DIFF
--- a/BancoDados/BancoDados/DAL/ProdutoDAO.cs
+++ b/BancoDados/BancoDados/DAL/ProdutoDAO.cs
@@ -23,13 +23,11 @@ namespace BancoDados.DAL
         }
         public static Produto BuscarProduto(string nome)
         {
-            Produto find;
             foreach (Produto p in ListarProdutos())
             {
                 if (nome == p.Nome)
                 {
-                    find = p;
-                    return find;
+                    return p;
                 }
             }
             return null;

--- a/BancoDados/BancoDados/View/Program.cs
+++ b/BancoDados/BancoDados/View/Program.cs
@@ -12,9 +12,6 @@ namespace BancoDados
         static void Main(string[] args)
         {
             int menu = 0;
-
-            
-
             do
             {
                 Console.WriteLine("1 - Cadastrar Produto");

--- a/BancoDados/BancoDados/View/RemoverProduto.cs
+++ b/BancoDados/BancoDados/View/RemoverProduto.cs
@@ -12,9 +12,8 @@ namespace BancoDados.View
     {
         public static void Renderizar()
         {
-
-            Produto produto = new Produto();
-            Console.WriteLine("Cadastrar Produto");
+            
+            Console.WriteLine("Remover Produto");
             Console.WriteLine("Digite o nome");
             ProdutoDAO.RemoverProduto(Console.ReadLine().ToLower());
         }


### PR DESCRIPTION
Utilizar o método Equals dentro da classe DAO para lógica do método que busca um produto dentro da lista de produtos no banco de dados lançou uma exceção que entrou em conflito com o cast feito dentro do método Equals sobrescrito na classe Produto para fazer a comparação via 'Nome'. Ou seja, o método Equals sobrescrito estava recebendo uma string como parâmetro ao invés de receber um objeto.